### PR TITLE
Use final namespace in output

### DIFF
--- a/src/Commands/SetupCommand.php
+++ b/src/Commands/SetupCommand.php
@@ -52,10 +52,8 @@ class SetupCommand extends Command
             $this->_print('Enter your project\'s namespace (example: MyProject):');
             $this->_lineBreak();
             $namespace = $this->listener->getInput();
-            $command->setName(empty($namespace)
-                ? 'MyProject'
-                : str_replace(' ', '', ucwords(strtolower($namespace)))
-            );
+            $namespace = empty($namespace) ? 'MyProject' : str_replace(' ', '', ucwords(strtolower($namespace)));        
+            $command->setName($namespace);
             $this->_print('------------------------------');
             $this->_lineBreak();
             $this->_print('Your plugin namespace is "%s"', $namespace);


### PR DESCRIPTION
This migrates the fix from wpmvc-commands into ayuco from;
https://github.com/10quality/wpmvc-commands/pull/13